### PR TITLE
Add support for mps DEVICE type

### DIFF
--- a/src/score_models/plot_utils.py
+++ b/src/score_models/plot_utils.py
@@ -11,7 +11,7 @@ from scipy.interpolate import interpn
 from scipy.special import logsumexp
 from matplotlib.colors import Normalize
 
-DEVICE = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+DEVICE = torch.device("cuda" if torch.cuda.is_available() else "mps" if torch.backends.mps.is_available() else "cpu")
 
 # plt.style.use('dark_background')
 plt.style.use('science')

--- a/src/score_models/toy_distributions.py
+++ b/src/score_models/toy_distributions.py
@@ -3,7 +3,7 @@ import numpy as np
 from torch.distributions import constraints
 from torch import distributions as tfd
 
-DEVICE = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+DEVICE = torch.device("cuda" if torch.cuda.is_available() else "mps" if torch.backends.mps.is_available() else "cpu")
 
 def swiss_roll(modes=128, size=0.1, width=0.1, spread=0.7, device=DEVICE) -> tfd.Distribution:
     """

--- a/src/score_models/utils.py
+++ b/src/score_models/utils.py
@@ -3,8 +3,7 @@ import torch
 import torch.nn as nn
 
 DTYPE = torch.float32
-DEVICE = torch.device('cuda:0' if torch.cuda.is_available() else "cpu")
-
+DEVICE = torch.device('cuda:0' if torch.cuda.is_available() else "mps" if torch.backends.mps.is_available() else "cpu")
 
 def get_norm_layer(norm_type='instance'):
     """Return a normalization layer


### PR DESCRIPTION
For using the device type [MPS](https://developer.apple.com/metal/pytorch/) on Mac

I left the notebooks since those are easy for the user to change